### PR TITLE
Added support for lein 2.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,29 @@ tools.deps.
 {:aliases {:nrepl {:extra-deps {nrepl/nrepl {:mvn/version "0.4.5"}}}
            :rebl {:extra-deps {
 	                  org.clojure/clojure {:mvn/version "1.10.0-RC3"}
-                      rickmoynihan/rebl.middleware {:git/url "git@github.com:RickMoynihan/nrebl.middleware.git", :sha "6f37f09fef0df14b855b443838f7dcc0ff6fd1d1"}
+                      rickmoynihan/nrebl.middleware {:git/url "https://github.com/rickmoynihan/dev.middleware", :sha "6f37f09fef0df14b855b443838f7dcc0ff6fd1d1"}
                       org.clojure/core.async {:mvn/version "0.4.490"}
      	              com.cognitect/rebl {:local/root "<PATH-TO-REBL-JAR>/REBL-0.9.108/REBL-0.9.108.jar"}}}
            :cider {,,,} ;; configure cider/nrepl deps here
            }}}}
+```
+
+## Leiningen Installation
+
+Add something like the following to your lein `project.clj`
+
+```clojure
+ :nrepl {:repl-options {:nrepl-middleware [nrebl.middleware/wrap-nrebl]
+                        ;; If you would like the REBL ui to start on repl init
+                        :init (do (println "Starting cognitect.rebl/ui...")
+                                  (cognitect.rebl/ui))})}
+         :dependencies [[rickmoynihan/nrebl.middleware "0.1.0-SNAPSHOT"]
+                        [org.clojure/core.async "0.4.490"]]
+
+         ;; Download REBL and add to :resource-paths
+         :resource-paths ["/Users/rick/Software/REBL-0.9.108/REBL-0.9.108.jar"]}
+
+ :repl [:nrebl]
 ```
 
 ## Usage
@@ -34,10 +52,16 @@ tools.deps.
 clj -A:nrepl:cider:rebl -m nrepl.cmdline --middleware '[nrebl.middleware/wrap-nrebl cider.nrepl/cider-middleware]'
 ```
 
-Then connect to your REPL, and run
+Then connect to your REPL. The REBL UI should display automatically but you can always run it manually:
 
 ```
 (cognitect.rebl/ui)
+```
+
+For leiningen users:
+
+```
+lein repl
 ```
 
 You should now be able to evaluate forms and have REBL capture them.

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,16 @@
+(defproject rickmoynihan/nrebl.middleware "0.1.0-SNAPSHOT"
+  :description "A clojure nREPL middleware for interacting with Cognitect’s REBL."
+  :url "https://github.com/rickmoynihan/nrebl.middleware"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies []
+  :exclusions [org.clojure/clojure
+               nrepl
+               cognitect.rebl]
+  :target-path "target/%s"
+  :profiles {:uberjar {:aot :all}
+             :test {:main ^:skip-aot nrebl.middleware
+                    :dependencies [[org.clojure/clojure "1.10.0-RC4"]
+                                   [org.clojure/core.async "0.4.490"]
+                                   [nrepl "0.4.5"]]
+                    :resource-paths ["resources/REBL-0.9.109.jar"]}})

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,6 @@
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}
              :test {:main ^:skip-aot nrebl.middleware
-                    :dependencies [[org.clojure/clojure "1.10.0-RC4"]
+                    :dependencies [[org.clojure/clojure "1.10.0"]
                                    [org.clojure/core.async "0.4.490"]
-                                   [nrepl "0.4.5"]]
-                    :resource-paths ["resources/REBL-0.9.109.jar"]}})
+                                   [nrepl "0.5.3"]]}})

--- a/src/nrebl/middleware.clj
+++ b/src/nrebl/middleware.clj
@@ -1,15 +1,23 @@
 (ns nrebl.middleware
-  (:require [nrepl
-             [middleware :refer [set-descriptor!]]
-             [transport :as transport]]
-            [nrepl.middleware.interruptible-eval :as ev]
-            [cognitect.rebl.ui :as ui]
-            [cognitect.rebl :as rebl]
-            [clojure.datafy :refer [datafy]])
-  (:import
-   nrepl.transport.Transport))
+  (:require [clojure.datafy :refer [datafy]]
+            [cognitect.rebl :as rebl]))
 
-(defn send-to-rebl! [{:keys [code] :as req} {:keys [value] :as resp}]
+  ;; Looks for legacy leiningen namespace and imports relevant resources
+(if (find-ns 'clojure.tools.nrepl)
+  (do (require
+       '[clojure.tools.nrepl.middleware :refer [set-descriptor!]])
+      (import
+       'clojure.tools.nrepl.transport.Transport))
+  (do (require
+       '[nrepl.middleware :refer [set-descriptor!]])
+      (import
+       'nrepl.transport.Transport)))
+
+(defn send-to-rebl!
+  "Displays evaluated code in REBL results.
+  Takes a nrepl middleware request map and a response map.
+  Returns a nrepl middleware response"
+  [{:keys [code] :as req} {:keys [value] :as resp}]
   (when-let [value (datafy value)]
     (rebl/submit (read-string code) value))
   resp)
@@ -17,7 +25,7 @@
 (defn- wrap-rebl-sender
   "Wraps a `Transport` with code which prints the value of messages sent to
   it using the provided function."
-  [{:keys [id op ^Transport transport] :as request} ]
+  [{:keys [id op ^Transport transport] :as request}]
   (reify Transport
     (recv [this]
       (.recv transport))
@@ -29,9 +37,14 @@
       this)))
 
 (defn wrap-nrebl [handler]
+  "nREPL middleware wrapper.
+  Takes the next middleware handler function.
+  Returns a middlware handler function.
+  See https://nrepl.xyz/nrepl/design/middleware.html for more."
   (fn [{:keys [id op transport] :as request}]
-    (if (= op "start-rebl-ui")
-      (rebl/ui)
+    ;; Using case so that it's easier to add\remove ops later
+    (case op
+      "start-rebl-ui" (rebl/ui)
       (handler (assoc request :transport (wrap-rebl-sender request))))))
 
 (set-descriptor! #'wrap-nrebl
@@ -49,17 +62,16 @@
      (-> (nrepl/client conn 1000)    ; message receive timeout required
          ;(nrepl/message {:op "inspect-nrebl" :code "[1 2 3 4 5 6 7 8 9 10 {:a :b :c :d :e #{5 6 7 8 9 10}}]"})
          (nrepl/message {:op "eval" :code "(do {:a :b :c [1 2 3 4] :d #{5 6 7 8} :e (range 20)})"})
-         nrepl/response-values
-         ))
+         nrepl/response-values))
+
 
   (with-open [conn (nrepl/connect :port 52756)]
      (-> (nrepl/client conn 1000)    ; message receive timeout required
          (nrepl/message {:op "start-rebl-ui"})
-         nrepl/response-values
-         ))
+         nrepl/response-values))
+
 
   (require '[nrepl.server :as ser])
 
   (def nrep (ser/start-server :port 55804
-                              :handler (ser/default-handler #'wrap-nrebl)))
-  )
+                              :handler (ser/default-handler #'wrap-nrebl))))


### PR DESCRIPTION
# Features

- Covers bare minimum amount of changes to support leiningen 2.8.1.
- Updated README.md
- Cleaned up unnecessary dependencies
- Added more docs to some of the functions

## Testing
1. Clone repo
2. Checkout lein-2.8.1 branch
3. Run `lein install`
4. Create test/lein-test-app directory
4. Run `cd test/nrebl/lein-test-app`
5. Create project.clj
   ```clj
   (defproject lein-test-app "0.1.0-SNAPSHOT"
    :dependencies [[rickmoynihan/nrebl.middleware "0.1.0-SNAPSHOT"]
                   [org.clojure/clojure "1.10.0-RC4"]
                   [org.clojure/core.async "0.4.490"]]
    :resource-paths ["resources/REBL-0.9.109.jar"]
    :repl-options {:nrepl-middleware [nrebl.middleware/wrap-nrebl]
                   :init (do (println "Starting cognitect.rebl/ui...")
                             (cognitect.rebl/ui))})
   ```
5. Run `lein repl`

Alternatively you could run `git fetch test-configs && git checkout test-configs test` to use preset deps and lein test configurations. See https://github.com/jayzawrotny/nrebl.middleware/tree/test-configs.

## Merging

You can see all these pull requests merged together in https://github.com/jayzawrotny/nrebl.middleware/blob/develop/src/nrebl/middleware.clj