### PR TITLE
Added fallback if cognitect.rebl is not found

### DIFF
--- a/src/nrebl/middleware.clj
+++ b/src/nrebl/middleware.clj
@@ -2,12 +2,22 @@
   (:require [nrepl
              [middleware :refer [set-descriptor!]]
              [transport :as transport]]
-            [nrepl.middleware.interruptible-eval :as ev]
-            [cognitect.rebl.ui :as ui]
-            [cognitect.rebl :as rebl]
             [clojure.datafy :refer [datafy]])
   (:import
    nrepl.transport.Transport))
+
+(def rebl-exists?
+  (try
+    (require '[cognitect.rebl :as rebl])
+    true
+    (catch java.io.FileNotFoundException _
+        false)))
+
+;; Ensure cognitect.rebl namespace exists
+(when-not rebl-exists?
+  (create-ns 'rebl)
+  (intern 'rebl 'submit identity)
+  (intern 'rebl 'ui identity))
 
 (defn send-to-rebl! [{:keys [code] :as req} {:keys [value] :as resp}]
   (when-let [value (datafy value)]
@@ -17,7 +27,7 @@
 (defn- wrap-rebl-sender
   "Wraps a `Transport` with code which prints the value of messages sent to
   it using the provided function."
-  [{:keys [id op ^Transport transport] :as request} ]
+  [{:keys [id op ^Transport transport] :as request}]
   (reify Transport
     (recv [this]
       (.recv transport))
@@ -28,11 +38,16 @@
              (send-to-rebl! request resp))
       this)))
 
-(defn wrap-nrebl [handler]
-  (fn [{:keys [id op transport] :as request}]
-    (if (= op "start-rebl-ui")
-      (rebl/ui)
-      (handler (assoc request :transport (wrap-rebl-sender request))))))
+(defn wrap-nrebl
+  [handler]
+  (if rebl-exists?
+    (fn [{:keys [id op transport] :as request}]
+      (cond
+        (= op "start-rebl-ui") (rebl/ui)
+        :else (handler (assoc request :transport (wrap-rebl-sender request)))))
+    (do
+      (println "WARNING: cognitect.rebl namespace was not found on classpath. nrebl.middlware could not be started.")
+      handler)))
 
 (set-descriptor! #'wrap-nrebl
                  {:requires #{}
@@ -49,17 +64,16 @@
      (-> (nrepl/client conn 1000)    ; message receive timeout required
          ;(nrepl/message {:op "inspect-nrebl" :code "[1 2 3 4 5 6 7 8 9 10 {:a :b :c :d :e #{5 6 7 8 9 10}}]"})
          (nrepl/message {:op "eval" :code "(do {:a :b :c [1 2 3 4] :d #{5 6 7 8} :e (range 20)})"})
-         nrepl/response-values
-         ))
+         nrepl/response-values))
+
 
   (with-open [conn (nrepl/connect :port 52756)]
      (-> (nrepl/client conn 1000)    ; message receive timeout required
          (nrepl/message {:op "start-rebl-ui"})
-         nrepl/response-values
-         ))
+         nrepl/response-values))
+
 
   (require '[nrepl.server :as ser])
 
   (def nrep (ser/start-server :port 55804
-                              :handler (ser/default-handler #'wrap-nrebl)))
-  )
+                              :handler (ser/default-handler #'wrap-nrebl))))


### PR DESCRIPTION
# Features

- Setup middleware to just forward requests to next handler if cognitect.rebl could be imported
- Warns user cognitect.rebl could not be found ```WARNING: cognitect.rebl namespace was not found on classpath. nrebl.middlware could not be started.```

## Testing

1. Create a test directory like test/deps-repl-test
2. Create a deps.edn file in test/deps-repl-test
    ```clj
    {:aliases {:nrepl {:extra-deps {nrepl/nrepl {:mvn/version "0.4.5"}}}
               :rebl {:extra-deps {org.clojure/clojure {:mvn/version "1.10.0-RC5"}
                                   rickmoynihan/rebl.middleware {:local/root "../.."}
                                   org.clojure/core.async {:mvn/version "0.4.490"}}}}}
                                   ; com.cognitect/rebl {:local/root "../../resources/REBL-0.9.109.jar"}}}
    ```
    
2. Run ```clj -A:nrepl:rebl -m nrepl.cmdline --middleware '[nrebl.middleware/wrap-nrebl]' --interactive```

If you leave the rebl dep in deps.edn commented out, it fails safely.

If you uncomment the rebl dep line and run the repl again it should work as expected.


Alternatively you could run `git fetch test-configs && git checkout test-configs test` to use preset deps and lein test configurations. See https://github.com/jayzawrotny/nrebl.middleware/tree/test-configs.


## Merging

You can see all these pull requests merged together in https://github.com/jayzawrotny/nrebl.middleware/blob/develop/src/nrebl/middleware.clj