### PR TITLE
Added support for Cursive

### DIFF
--- a/src/nrebl/middleware.clj
+++ b/src/nrebl/middleware.clj
@@ -5,7 +5,8 @@
             [nrepl.middleware.interruptible-eval :as ev]
             [cognitect.rebl.ui :as ui]
             [cognitect.rebl :as rebl]
-            [clojure.datafy :refer [datafy]])
+            [clojure.datafy :refer [datafy]]
+            [clojure.string :refer [starts-with?]])
   (:import
    nrepl.transport.Transport))
 
@@ -14,18 +15,28 @@
     (rebl/submit (read-string code) value))
   resp)
 
+
+(defn- cursive?
+  "Takes an nREPL request and returns true if a noisy cursive eval request."
+  [request]
+  (and (= (get request :op) "eval")
+       (starts-with? (get request :code) "(cursive.repl")))
+
 (defn- wrap-rebl-sender
   "Wraps a `Transport` with code which prints the value of messages sent to
   it using the provided function."
-  [{:keys [id op ^Transport transport] :as request} ]
+  [{:keys [id op ^Transport transport] :as request}]
   (reify Transport
     (recv [this]
       (.recv transport))
     (recv [this timeout]
       (.recv transport timeout))
-    (send [this resp]
+    (send [this response]
       (.send transport
-             (send-to-rebl! request resp))
+             ;; Filter out noisy cursive requests
+             (if (cursive? request)
+               response
+               (send-to-rebl! request response)))
       this)))
 
 (defn wrap-nrebl [handler]


### PR DESCRIPTION
# Features
- Filters out noisy Cursive messages

## Testing

1. Create a test directory like test/deps-test

    ```clj
    {:aliases {:nrepl {:extra-deps {nrepl/nrepl {:mvn/version "0.4.5"}}}
               :rebl {:extra-deps {org.clojure/clojure {:mvn/version "1.10.0-RC3"}
                                   rickmoynihan/rebl.middleware {:local/root "../.."}
                                   org.clojure/core.async {:mvn/version "0.4.490"}
                                   com.cognitect/rebl {:local/root "../../resources/REBL-0.9.109.jar"}}}}}
    ```
2. Start the REPL
    ```
    clj A:nrepl:rebl -m nrepl.cmdline --middleware '[nrebl.middleware/wrap-nrebl]' --interactive
    ```
    
4. Open test/deps-test in IntelliJ with Cursive
5. Have Cursive connect to an existing nrepl server
6. Evaluate some code


Alternatively you could run `git fetch test-configs && git checkout test-configs test` to use preset deps and lein test configurations. See https://github.com/jayzawrotny/nrebl.middleware/tree/test-configs.

## Merging

You can see all these pull requests merged together in https://github.com/jayzawrotny/nrebl.middleware/blob/develop/src/nrebl/middleware.clj