### PR TITLE
Updated deps.edn for latest nREPL and Clojure versions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,8 @@
 {:paths ["resources" "src"]
  :deps {org.clojure/clojure {:mvn/version "RELEASE"}
-        nrepl/nrepl {:mvn/version "0.4.5"}}
+        nrepl/nrepl {:mvn/version "0.5.3"}}
 
  :aliases
- {:dev {:extra-deps {org.clojure/clojure {:mvn/version "1.10.0-RC3"}
+ {:dev {:extra-deps {org.clojure/clojure {:mvn/version "1.10.0"}
                      org.clojure/core.async {:mvn/version "0.4.490"}
-	             com.cognitect/rebl {:local/root "/Users/rick/Software/REBL-0.9.108/REBL-0.9.108.jar"}}}
-  }}
+                     com.cognitect/rebl {:local/root "/Users/rick/Software/REBL-0.9.108/REBL-0.9.108.jar"}}}}}


### PR DESCRIPTION
# Features

- Updates nREPL to 0.5.3 which fixes issues when submitting forms to REBL
- Updates clojure to 1.10.0 since it's an official release now

## Merging

You can see all these pull requests merged together in https://github.com/jayzawrotny/nrebl.middleware/blob/develop/src/nrebl/middleware.clj
