### PR TITLE
Wrap value in read-string

### DIFF
--- a/src/nrebl/middleware.clj
+++ b/src/nrebl/middleware.clj
@@ -25,8 +25,9 @@
         false)))
 
 (defn send-to-rebl! [{:keys [code] :as req} {:keys [value] :as resp}]
-  (when-let [value (datafy value)]
-    (rebl/submit (read-string code) value))
+  (when value
+    (rebl/submit (read-string code)
+                 (datafy (read-string value))))
   resp)
 
 (defn- wrap-rebl-sender


### PR DESCRIPTION
When using nrebl.middleare with Cursive, the values in the REBL where wrapped with double quotes. The value from nrepl whould be a readable string. This patch checks that the value is present (it might not be for all responese, in particular `:status #{:done}` has no `:value`.), then it will `(read-string)` on that before passing it to datafy.

**I have not tested in any other environment other than _Cursive_**

Relates to issue #15 