### PR TITLE
Ensure wrap-nrebl is applied after nREPL's printing middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,8 @@
                                        [org.openjfx/javafx-web "11.0.1"]]
                         :resource-paths ["vendor/REBL-0.9.109.jar"]}
 
+             :repl {:repl-options {:nrepl-middleware [nrebl.middleware/wrap-nrebl]}}
+
              :dev {:dependencies [[nrepl "0.5.3"]]} ;; Used by lein 2.8.3+
              :dev-old {:dependencies [[org.clojure/tools.nrepl "0.2.13"]]} ;; lein < 2.8.3
              }

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,12 @@
                         ["snapshots" :clojars]]
 
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.0"]
-                                       [org.clojure/core.async "0.4.490"]]
+                                       [org.clojure/core.async "0.4.490"]
+                                       [org.openjfx/javafx-base "11.0.1"]
+                                       [org.openjfx/javafx-controls "11.0.1"]
+                                       [org.openjfx/javafx-fxml "11.0.1"]
+                                       [org.openjfx/javafx-swing "11.0.1"]
+                                       [org.openjfx/javafx-web "11.0.1"]]
                         :resource-paths ["vendor/REBL-0.9.109.jar"]}
 
              :dev {:dependencies [[nrepl "0.5.3"]]} ;; Used by lein 2.8.3+

--- a/src/nrebl/middleware.clj
+++ b/src/nrebl/middleware.clj
@@ -24,6 +24,14 @@
       (catch java.io.FileNotFoundException _
         false)))
 
+(def ^:private print-middleware
+  (some resolve '[;; ctn 0.2.13 and earlier
+                  clojure.tools.nrepl.middleware.pr-values/pr-values
+                  ;; nrepl 0.3.0 to 0.5.3
+                  nrepl.middleware.pr-values/pr-values
+                  ;; nrepl 0.6.0+
+                  nrepl.middleware.print/wrap-print]))
+
 (defn send-to-rebl! [{:keys [code] :as req} {:keys [value] :as resp}]
   (when-let [value (datafy value)]
     (rebl/submit (read-string code) value))
@@ -50,7 +58,7 @@
       (handler (assoc request :transport (wrap-rebl-sender request))))))
 
 (set-descriptor! #'wrap-nrebl
-                 {:requires #{}
+                 {:requires #{print-middleware}
                   :expects #{"eval"}
                   :handles {"start-rebl-ui" "Launch the REBL inspector and have it capture interactions over nREPL"}})
 


### PR DESCRIPTION
Fixes #15. By enforcing this ordering we can be sure the `wrap-rebl-sender` transport will handle responses before the printing middleware's transport does.

Two other small (dev-time only) changes:

* Add `wrap-nrebl` to the default middleware in the `:repl` profile in the project config
* Add necessary dependencies for JDK11 to the `:provided` profile