### PR TITLE
Ensure wrap-nrebl is applied after nREPL's printing middleware 2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,35 @@
+{:paths ["src"]
+ :aliases {:nrepl {:extra-deps {nrepl {:mvn/version "0.6.0"}}
+                   :main-opts ["-m" "nrepl.cmdline"]}
+
+           :rebl {:extra-deps {com.cognitect/rebl {:local/root "vendor/REBL-0.9.220.jar"}}}
+
+           ;; Oracle JDK 8
+           :jfx-8 {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
+                                org.clojure/core.async {:mvn/version "0.4.490"}}}
+
+           ;; Open JDK 11
+           :jfx-11
+           {:extra-deps {org.clojure/core.async {:mvn/version "0.4.490"}
+                         ;; deps for file datafication (0.9.149 or later)
+                         org.clojure/data.csv {:mvn/version "0.1.4"}
+                         org.clojure/data.json {:mvn/version "0.2.3"}
+                         org.yaml/snakeyaml {:mvn/version "1.23"}
+                         com.cognitect/rebl
+                         ;; adjust to match your install location
+                         {:local/root "vendor/REBL-0.9.220.jar"}
+                         org.openjfx/javafx-fxml     {:mvn/version "11.0.1"}
+                         org.openjfx/javafx-controls {:mvn/version "11.0.1"}
+                         org.openjfx/javafx-graphics {:mvn/version "11.0.1"}
+                         org.openjfx/javafx-media    {:mvn/version "11.0.1"}
+                         org.openjfx/javafx-swing    {:mvn/version "11.0.1"}
+                         org.openjfx/javafx-base     {:mvn/version "11.0.1"}
+                         org.openjfx/javafx-web      {:mvn/version "11.0.1"}}
+            :main-opts ["-m" "cognitect.rebl"]}
+
+           :cider-22 {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
+                                   cider/cider-nrepl {:mvn/version "0.22.1"}}
+                      :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
+
+
+           :nrebl {:main-opts ["-e" "((requiring-resolve,'cognitect.rebl/ui))" "-m" "nrepl.cmdline" "-i" "--middleware" "[nrebl.middleware/wrap-nrebl,cider.nrepl/cider-middleware]"]}}}

--- a/project.clj
+++ b/project.clj
@@ -8,13 +8,30 @@
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
 
-  :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.0"]
-                                       [org.clojure/core.async "0.4.490"]]
-                        :resource-paths ["vendor/REBL-0.9.109.jar"]}
+  :profiles {:provided {
+
+                        :dependencies [[org.clojure/clojure "1.10.0"]
+                                       [org.clojure/core.async "0.4.490"]
+
+
+                                       ;; JDK 11
+                                       ;; [org.openjfx/javafx-base "11.0.1"]
+                                       ;; [org.openjfx/javafx-controls "11.0.1"]
+                                       ;; [org.openjfx/javafx-fxml "11.0.1"]
+                                       ;; [org.openjfx/javafx-swing "11.0.1"]
+                                       ;; [org.openjfx/javafx-web "11.0.1"]
+
+                                       ]
+
+                        :resource-paths ["vendor/REBL-0.9.149.jar"]}
+
 
              :repl {:repl-options {:nrepl-middleware [nrebl.middleware/wrap-nrebl]}}
 
-             :dev {:dependencies [[nrepl "0.5.3"]]} ;; Used by lein 2.8.3+
+             ;;:dev {:dependencies [[nrepl "0.6.0"]]} ;; Used by lein 2.8.3+ if you're on leiningen 2.9.0+ you can omit this
+
              :dev-old {:dependencies [[org.clojure/tools.nrepl "0.2.13"]]} ;; lein < 2.8.3
              }
+
+  :min-lein-version "2.9.0" ;; nrepl 0.6.0
   )

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
 
   :profiles {:provided {
 
-                        :dependencies [[org.clojure/clojure "1.10.0"]
+                        :dependencies [[org.clojure/clojure "1.10.1"]
                                        [org.clojure/core.async "0.4.490"]
 
 
@@ -23,15 +23,10 @@
 
                                        ]
 
-                        :resource-paths ["vendor/REBL-0.9.149.jar"]}
+                        :resource-paths ["vendor/REBL-0.9.220.jar"]}
 
 
-             :repl {:repl-options {:nrepl-middleware [nrebl.middleware/wrap-nrebl]}}
-
-             ;;:dev {:dependencies [[nrepl "0.6.0"]]} ;; Used by lein 2.8.3+ if you're on leiningen 2.9.0+ you can omit this
-
-             :dev-old {:dependencies [[org.clojure/tools.nrepl "0.2.13"]]} ;; lein < 2.8.3
-             }
+             :repl {:repl-options {:nrepl-middleware [nrebl.middleware/wrap-nrebl]}}}
 
   :min-lein-version "2.9.0" ;; nrepl 0.6.0
   )

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,8 @@
                                        [org.clojure/core.async "0.4.490"]]
                         :resource-paths ["vendor/REBL-0.9.109.jar"]}
 
+             :repl {:repl-options {:nrepl-middleware [nrebl.middleware/wrap-nrebl]}}
+
              :dev {:dependencies [[nrepl "0.5.3"]]} ;; Used by lein 2.8.3+
              :dev-old {:dependencies [[org.clojure/tools.nrepl "0.2.13"]]} ;; lein < 2.8.3
              }

--- a/src/nrebl/middleware.clj
+++ b/src/nrebl/middleware.clj
@@ -1,36 +1,11 @@
 (ns nrebl.middleware
-  (:require [cognitect.rebl.ui :as ui]
+  (:require [clojure.datafy :refer [datafy]]
             [cognitect.rebl :as rebl]
-            [clojure.datafy :refer [datafy]]))
-
-(defn try-loading-new-nrepl! []
-  (require '[nrepl.middleware :refer [set-descriptor!]])
-  (require '[nrepl.transport :as transport])
-  (import '[nrepl.transport Transport])
-  true)
-
-(defn try-loading-old-nrepl! []
-  (require '[clojure.tools.nrepl.middleware :refer [set-descriptor!]])
-  (require '[clojure.tools.nrepl.transport :as transport])
-  (import '[clojure.tools.nrepl.transport Transport])
-  true)
-
-(or (try
-      (try-loading-new-nrepl!)
-      (catch java.io.FileNotFoundException _
-        false))
-    (try
-      (try-loading-old-nrepl!)
-      (catch java.io.FileNotFoundException _
-        false)))
-
-(def ^:private print-middleware
-  (some resolve '[;; ctn 0.2.13 and earlier
-                  clojure.tools.nrepl.middleware.pr-values/pr-values
-                  ;; nrepl 0.3.0 to 0.5.3
-                  nrepl.middleware.pr-values/pr-values
-                  ;; nrepl 0.6.0+
-                  nrepl.middleware.print/wrap-print]))
+            [cognitect.rebl.ui :as ui]
+            [nrepl.middleware.print :refer [wrap-print]]
+            [nrepl.middleware :refer [set-descriptor!]]
+            [nrepl.transport :as transport])
+  (:import [nrepl.transport Transport]))
 
 (defn send-to-rebl! [{:keys [code] :as req} {:keys [value] :as resp}]
   (and
@@ -60,7 +35,7 @@
       (handler (assoc request :transport (wrap-rebl-sender request))))))
 
 (set-descriptor! #'wrap-nrebl
-                 {:requires #{print-middleware}
+                 {:requires #{#'wrap-print}
                   :expects #{"eval"}
                   :handles {"start-rebl-ui" "Launch the REBL inspector and have it capture interactions over nREPL"}})
 

--- a/src/nrebl/middleware.clj
+++ b/src/nrebl/middleware.clj
@@ -24,6 +24,14 @@
       (catch java.io.FileNotFoundException _
         false)))
 
+(def ^:private print-middleware
+  (some resolve '[;; ctn 0.2.13 and earlier
+                  clojure.tools.nrepl.middleware.pr-values/pr-values
+                  ;; nrepl 0.3.0 to 0.5.3
+                  nrepl.middleware.pr-values/pr-values
+                  ;; nrepl 0.6.0+
+                  nrepl.middleware.print/wrap-print]))
+
 (defn send-to-rebl! [{:keys [code] :as req} {:keys [value] :as resp}]
   (and
     code
@@ -52,7 +60,7 @@
       (handler (assoc request :transport (wrap-rebl-sender request))))))
 
 (set-descriptor! #'wrap-nrebl
-                 {:requires #{}
+                 {:requires #{print-middleware}
                   :expects #{"eval"}
                   :handles {"start-rebl-ui" "Launch the REBL inspector and have it capture interactions over nREPL"}})
 


### PR DESCRIPTION
Force a better ordering on middlewares to ensure we can rely on them with regards to eval/print etc, and add support for nrepl 0.6.0 and leiningen 2.9.0