### PR TITLE
Protect against code causing read-string to throw a NPE

### DIFF
--- a/src/nrebl/middleware.clj
+++ b/src/nrebl/middleware.clj
@@ -25,8 +25,10 @@
         false)))
 
 (defn send-to-rebl! [{:keys [code] :as req} {:keys [value] :as resp}]
-  (when-let [value (datafy value)]
-    (rebl/submit (read-string code) value))
+  (and
+    code
+    (when-let [value (datafy value)]
+      (rebl/submit (read-string code) value)))
   resp)
 
 (defn- wrap-rebl-sender


### PR DESCRIPTION
Sometimes, the `code` is nil, and the middleware blows up. I see this in Cursive, and it's not repeatable - happens every now and again.