### PR TITLE
capture repl calls that return falsy values

### DIFF
--- a/src/nrebl/middleware.clj
+++ b/src/nrebl/middleware.clj
@@ -9,7 +9,7 @@
 
 
 (defn send-to-rebl! [{:keys [code] :as req} {:keys [value] :as resp}]
-  (when (and code value)
+  (when (and code (contains? resp :value))
         (rebl/submit (read-string code) value))
   resp)
 


### PR DESCRIPTION
Currently repl evaluations that return nil or false do not show up in REBL.
This might be intentional because you cannot browse into these values, but I found it confusing that some calls did not show up in REBL.